### PR TITLE
Show only research groups where the logged-in user is a member

### DIFF
--- a/app/Http/Controllers/ResearchGroupController.php
+++ b/app/Http/Controllers/ResearchGroupController.php
@@ -28,8 +28,12 @@ class ResearchGroupController extends Controller
 
     public function index()
     {
+        $userId = auth()->id();
+
         \Log::info('Showing Research Groups');
-        $researchGroups = ResearchGroup::with('User')->get();
+        $researchGroups = ResearchGroup::whereHas('user', function ($query) use ($userId) {
+            $query->where('users.id', $userId);
+        })->with('user')->get();
         return view('research_groups.index', compact('researchGroups'));
     }
 


### PR DESCRIPTION
Updated `index()` in `ResearchGroupController` to display only research groups where the logged-in user is a member.